### PR TITLE
Replace usage of deprecated std_cmake_parameters with it's replacement std_cmake_args

### DIFF
--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -3,8 +3,8 @@ require 'formula'
 class Audiowaveform < Formula
   desc "C++ program to generate waveform data and render waveform images from audio files"
   homepage "https://github.com/bbc/audiowaveform"
-  url "https://github.com/bbc/audiowaveform/archive/1.0.11.tar.gz"
-  sha256 "37722b4230aaaf1e5936d9ffa7a827ca9c3f9e2d0f39245122dd2c5ac1e4f0b8"
+  url "https://github.com/bbc/audiowaveform/archive/1.1.0.tar.gz"
+  sha256 "2c1a01fcb2297197c43ef920b7088f9ed93ce68ffcacc3ad9e50b2622e64aebc"
 
   depends_on "cmake"
   depends_on "libmad"

--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -19,7 +19,7 @@ class Audiowaveform < Formula
   # depends_on "gmock"
 
   def install
-    cmake_args = std_cmake_parameters.split
+    cmake_args = std_cmake_args
     cmake_args << "-DENABLE_TESTS=0"
     cmake_args << "-DCMAKE_C_COMPILER=/usr/bin/clang"
     cmake_args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"


### PR DESCRIPTION
I saw the deprecation notice when I tapped and installed this formula a few minutes ago, and it looks like it was pretty easy to fix!