### PR TITLE
Update audiowaveform to 1.8.1

### DIFF
--- a/audiowaveform.rb
+++ b/audiowaveform.rb
@@ -1,15 +1,13 @@
-require 'formula'
-
 class Audiowaveform < Formula
-  desc "C++ program to generate waveform data and render waveform images from audio files"
+  desc "Program to generate waveform data and render waveform images from audio files"
   homepage "https://github.com/bbc/audiowaveform"
-  url "https://github.com/bbc/audiowaveform/archive/1.8.0.tar.gz"
-  sha256 "61da8ed371619e5227315ad83763ca56def6a74a5e6f027e06f5dfabad8a4f16"
+  url "https://github.com/bbc/audiowaveform/archive/1.8.1.tar.gz"
+  sha256 "bd1254a4ddbc0eb68eb8dbd549335c3207260afdae4bf80cfe5d4129de51d1e7"
   depends_on "cmake"
-  depends_on "libmad"
-  depends_on "libid3tag"
-  depends_on "libsndfile"
   depends_on "gd"
+  depends_on "libid3tag"
+  depends_on "libmad"
+  depends_on "libsndfile"
 
   if MacOS.version < :mavericks
     depends_on "boost" => "c++11"
@@ -23,7 +21,7 @@ class Audiowaveform < Formula
     cmake_args << "-DENABLE_TESTS=0"
     cmake_args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
 
-    on_macos do
+    if OS.mac?
       cmake_args << "-DCMAKE_C_COMPILER=/usr/bin/clang"
       cmake_args << "-DCMAKE_CXX_COMPILER=/usr/bin/clang++"
     end


### PR DESCRIPTION
Besides updating the version, this pull request also fixes a few warnings emitted by brew audit that were trivial to fix:
- `require 'formula'` is no longer needed.
- The description was too long.
- I fixed the order of the dependencies.
- Instead of `on_macos`, `if OS.mac?` should be used.